### PR TITLE
Add hackernews asset

### DIFF
--- a/dagster.yaml
+++ b/dagster.yaml
@@ -6,6 +6,9 @@ run_queue:
   - key: "concurrency_group"
     value: fmp
     limit: 4
+  - key: "concurrency_group"
+    value: hackernews
+    limit: 1
   max_concurrent_runs: 20
 telemetry:
   enabled: false

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -17,6 +17,7 @@ from integrations.jobs.regular import job as regular_job, assets as regular_asse
 from integrations.jobs.wikipedia import job as wikipedia_job, assets as wikipedia_assets
 from integrations.jobs.internal import job as internal_job, assets as internal_assets
 from integrations.jobs.unctad import job as unctad_job, assets as unctad_assets
+from integrations.jobs.hackernews import job as hackernews_job, assets as hackernews_assets
 
 ENV = os.environ.get("ENV", "dev")
 
@@ -31,6 +32,7 @@ assets = [
     *wikipedia_assets,
     *internal_assets,
     *unctad_assets,
+    *hackernews_assets,
 ]
 
 jobs = [
@@ -41,6 +43,7 @@ jobs = [
     wikipedia_job,
     internal_job,
     unctad_job,
+    hackernews_job,
 ]
 defs = Definitions(
     assets=assets,

--- a/integrations/assets/ycombinator/hackernews.py
+++ b/integrations/assets/ycombinator/hackernews.py
@@ -1,0 +1,44 @@
+from dagster import asset, StaticPartitionsDefinition
+import pandas as pd
+import requests
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import time
+
+def id_range_partitions():
+    start_id = 1
+    max_id = 39 * 1000 * 1000
+    partition_size = 10000 
+
+    return [f"{i}-{min(i + partition_size - 1, max_id)}" for i in range(start_id, max_id, partition_size)]
+
+id_partitions = StaticPartitionsDefinition(partition_keys=id_range_partitions())
+
+def fetch_item(item_id, retry_count=3, delay=5):
+    url = f"https://hacker-news.firebaseio.com/v0/item/{item_id}.json?print=pretty"
+    
+    for attempt in range(retry_count):
+        response = requests.get(url)
+        if response.status_code == 200:
+            return response.json()
+        elif response.status_code == 429: 
+            time.sleep(delay) 
+        else:
+            break
+
+    return None
+
+@asset(partitions_def=id_partitions)
+def hacker_news_items(context):
+    start_id, end_id = [int(x) for x in context.partition_key.split('-')]
+    items = []
+
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        future_to_id = {executor.submit(fetch_item, item_id): item_id for item_id in range(start_id, end_id + 1)}
+
+        for future in as_completed(future_to_id):
+            item_id = future_to_id[future]
+            item = future.result()
+            if item:
+                items.append(item)
+
+    return pd.DataFrame(items)

--- a/integrations/jobs/hackernews.py
+++ b/integrations/jobs/hackernews.py
@@ -1,0 +1,19 @@
+from dagster import define_asset_job, load_assets_from_modules
+import integrations.assets.ycombinator.hackernews as hackernews_assets
+
+assets = load_assets_from_modules(modules=[hackernews_assets])
+
+job = define_asset_job(
+    name='hackernews',
+    selection=assets,
+    tags={"concurrency_group": "hackernews"},
+    config={
+        "execution": {
+            "config": {
+                "multiprocess": {
+                    "max_concurrent": 1,
+                },
+            }
+        }
+    }
+)


### PR DESCRIPTION
Crawls all hackernews entities 'items', which can be comments, submissions, etc. For now it stops at id=39m, this should be enough for a while. In the future we should retrieve the latest id and dynamically create the partitions based on that.