### PR TITLE
gke increase webserver resources

### DIFF
--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -168,12 +168,12 @@ dagsterWebserver:
 
   # If you want to specify resources, uncomment the following lines, adjust them as necessary,
   # and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 2Gi
+  requests:
+    cpu: 1000m
+    memory: 2Gi
   # Readiness probe detects when the pod is ready to serve requests.
   # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes
   readinessProbe:


### PR DESCRIPTION
When many pods are being launched, the webservers resources are throttled. This change guarantees resources for the webserver. T